### PR TITLE
refactor: used `uv` to clear plugin cache

### DIFF
--- a/lua/lsp-toggle/fileutils.lua
+++ b/lua/lsp-toggle/fileutils.lua
@@ -108,7 +108,6 @@ function M.clear_cache(path)
 		end
 	end
 
-	vim.notify('Cleared cache, you should probably restart nvim', vim.log.levels.WARN)
 	return vim.uv.fs_rmdir(path)
 end
 

--- a/plugin/lsp-toggle.lua
+++ b/plugin/lsp-toggle.lua
@@ -17,4 +17,5 @@ end, {
 
 vim.api.nvim_create_user_command('ToggleLSPClearCache', function()
 	fileutils.clear_cache()
+	vim.notify('Cleared cache, you should probably restart nvim', vim.log.levels.WARN)
 end, { desc = 'Clear the local cache for lsp-toggle' })


### PR DESCRIPTION
## Description

For consistency, I've implemented a new fileutils function to clear cache, and the command to clear cache now calls it.

I've tested it, so it works as far as I know.