### PR TITLE
fix(window): replaced deprecated functions

### DIFF
--- a/lua/lsp-toggle/window.lua
+++ b/lua/lsp-toggle/window.lua
@@ -15,9 +15,9 @@ function M.print_display(clients)
 
 	local safe_fn = vim.schedule_wrap(function()
 		vim.api.nvim_buf_set_lines(M.window_buf, 0, -1, false, M.out_buf_table)
-		vim.api.nvim_buf_set_option(M.window_buf, 'modifiable', false)
+		vim.api.nvim_set_option_value('modifiable', false, { buf = M.window_buf })
 	end)
-	vim.api.nvim_buf_set_option(M.window_buf, 'modifiable', true)
+	vim.api.nvim_set_option_value('modifiable', true, { buf = M.window_buf })
 	safe_fn()
 end
 


### PR DESCRIPTION
## Changes

`vim.api.nvim_buf_set_option()` is deprecated. Fixed that.