### PR TITLE
ci: fixed `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @NeoSahadeo
-/.github/* @DrKJeff16
-/plugin/* @DrKJeff16
-/lua/lsp-toggle/config.lua @DrKJeff16
+.github/* @DrKJeff16
+plugin/* @DrKJeff16
+lua/lsp-toggle/config.lua @DrKJeff16


### PR DESCRIPTION
## Description

I think I messed up with the `CODEOWNERS` syntax.