### PR TITLE
fix(window): flush the buffer with an autocmd

### DIFF
--- a/lua/lsp-toggle/fileutils.lua
+++ b/lua/lsp-toggle/fileutils.lua
@@ -43,7 +43,7 @@ function M.produce_path()
 	return string.format('%s/%s.json', M.root_dir, file_name)
 end
 
----@param data table<string, { enabled: boolean, server_name: string }>
+---@param data table<string, lsp_toggle.tb_server>
 ---@return boolean|nil
 function M.save(data)
 	local path = M.produce_path()
@@ -62,7 +62,7 @@ function M.save(data)
 	return true
 end
 
----@return table<string, { enabled: boolean, server_name: string }>|nil
+---@return table<string, lsp_toggle.tb_server>|nil
 function M.load()
 	-- returns lspClients
 	local path = M.produce_path()

--- a/lua/lsp-toggle/utils.lua
+++ b/lua/lsp-toggle/utils.lua
@@ -1,8 +1,13 @@
+---@class lsp_toggle.tb_server
+---@field enabled boolean
+---@field server_name string
+---@field is_attached fun(): boolean
+
 local fileutils = require('lsp-toggle.fileutils')
 
 local M = {}
 
----@type table<string, { enabled: boolean, server_name: string }>
+---@type table<string, lsp_toggle.tb_server>
 M.clients = {}
 
 function M.load_all_clients()
@@ -14,6 +19,15 @@ function M.load_all_clients()
 			M.clients[client.name] = {
 				enabled = vim.lsp.is_enabled(client.name),
 				server_name = client.name,
+				is_attached = function()
+					-- NOTE: Using `pairs()` because it is not a list, strictly
+					for _, v in pairs(client.attached_buffers) do
+						if v then
+							return true
+						end
+					end
+					return false
+				end,
 			}
 		else
 			M.clients[client.name] = nil

--- a/lua/lsp-toggle/window.lua
+++ b/lua/lsp-toggle/window.lua
@@ -5,16 +5,18 @@ local M = {}
 ---@type string[]
 M.out_buf_table = {}
 
----@param clients table<string, { enabled: boolean, server_name: string }>
+---@param clients table<string, lsp_toggle.tb_server>
 function M.print_display(clients)
 	M.out_buf_table = {}
 
 	-- NOTE: Using `#clients` is not reliable because `clients` is not list-like
 	for _, tb_server in pairs(clients) do
-		table.insert(
-			M.out_buf_table,
-			(tb_server.enabled and '[x] ' or '[ ] ') .. tb_server.server_name
-		)
+		if tb_server.is_attached() then
+			table.insert(
+				M.out_buf_table,
+				(tb_server.enabled and '[x] ' or '[ ] ') .. tb_server.server_name
+			)
+		end
 	end
 
 	local safe_fn = vim.schedule_wrap(function()


### PR DESCRIPTION
## Description

I believe I solved the buffer not flushing, even with `<C-o>`. I used a `BufLeave` autocommand for it to trigger.
Comments have been added to specify what's been done.

I reuse the `'lsp-toggle'` augroup (not clearing it this time).