### PR TITLE
fix: `fileutils` and `utils` improvements

### DIFF
--- a/lua/lsp-toggle/fileutils.lua
+++ b/lua/lsp-toggle/fileutils.lua
@@ -51,11 +51,6 @@ function M.save(data)
 		return false
 	end
 
-	local stat = vim.uv.fs_stat(path)
-	if not stat or stat.type ~= 'file' then
-		return false
-	end
-
 	local fd = vim.uv.fs_open(path, 'w', tonumber('644', 8))
 	if not fd then
 		return false

--- a/lua/lsp-toggle/fileutils.lua
+++ b/lua/lsp-toggle/fileutils.lua
@@ -71,24 +71,24 @@ function M.load()
 	-- returns lspClients
 	local path = M.produce_path()
 	if not path then
-		return nil
+		return
 	end
 
 	local stat = vim.uv.fs_stat(path)
 	if not stat then
-		return nil
+		return
 	end
 
 	local fd = vim.uv.fs_open(path, 'r', tonumber('644', 8))
-
 	if not fd then
-		return nil
+		return
 	end
 
 	local content = vim.uv.fs_read(fd, stat.size)
 	vim.uv.fs_close(fd)
+
 	if not content then
-		return nil
+		return
 	end
 
 	return vim.fn.json_decode(content)
@@ -102,7 +102,7 @@ function M.clear_cache(path)
 
 	if not stat or stat.type ~= 'directory' then
 		vim.notify('No cache to clear!', vim.log.levels.WARN)
-		return nil
+		return
 	end
 
 	local dir = vim.uv.fs_scandir(path)

--- a/lua/lsp-toggle/fileutils.lua
+++ b/lua/lsp-toggle/fileutils.lua
@@ -23,12 +23,12 @@ end
 ---@param path string
 function M.set_file_path(path)
 	if vim.fn.has('nvim-0.11') == 1 then
-		vim.validate('path', path, 'string', true)
+		vim.validate('path', path, 'string', false)
 	else
-		vim.validate({ path = { path, { 'string', 'nil' } } })
+		vim.validate({ path = { path, 'string' } })
 	end
 
-	M.file_path = path or M.file_path
+	M.file_path = path
 end
 
 ---@return string

--- a/lua/lsp-toggle/fileutils.lua
+++ b/lua/lsp-toggle/fileutils.lua
@@ -94,28 +94,28 @@ function M.load()
 	return vim.fn.json_decode(content)
 end
 
----@param path? string
-function M.clear_cache(path)
-	path = path or M.root_dir
+---@param dir? string
+function M.clear_cache(dir)
+	dir = dir or M.root_dir
 
-	local stat = vim.uv.fs_stat(path)
+	local stat = vim.uv.fs_stat(dir)
 
 	if not stat or stat.type ~= 'directory' then
 		vim.notify('No cache to clear!', vim.log.levels.WARN)
 		return
 	end
 
-	local dir = vim.uv.fs_scandir(path)
+	local dir_scan = vim.uv.fs_scandir(dir)
 
 	while true do
-		---@type string?, 'directory'|'file'?
-		local item, item_type = vim.uv.fs_scandir_next(dir)
+		---@type string?, 'directory'|'file'|string?
+		local item, item_type = vim.uv.fs_scandir_next(dir_scan)
 
 		if not item then
 			break
 		end
 
-		item = path .. '/' .. item
+		item = dir .. '/' .. item
 
 		if item_type == 'file' then
 			vim.uv.fs_unlink(item)
@@ -124,7 +124,7 @@ function M.clear_cache(path)
 		end
 	end
 
-	return vim.uv.fs_rmdir(path)
+	return vim.uv.fs_rmdir(dir)
 end
 
 return M

--- a/lua/lsp-toggle/fileutils.lua
+++ b/lua/lsp-toggle/fileutils.lua
@@ -40,21 +40,25 @@ function M.produce_path()
 	local opts = require('lsp-toggle.config').options
 
 	local file_name = opts.cache_type == 'file_type' and M.file_type or djb2(M.file_path)
-	return string.format('%s/%s.json', M.root_dir, file_name)
+	return ('%s/%s.json'):format(M.root_dir, file_name)
 end
 
 ---@param data table<string, { enabled: boolean, server_name: string }>
----@return boolean|nil
+---@return boolean
 function M.save(data)
 	local path = M.produce_path()
+	if not path or path == '' then
+		return false
+	end
 
-	if not path then
-		return nil
+	local stat = vim.uv.fs_stat(path)
+	if not stat or stat.type ~= 'file' then
+		return false
 	end
 
 	local fd = vim.uv.fs_open(path, 'w', tonumber('644', 8))
 	if not fd then
-		return nil
+		return false
 	end
 
 	vim.uv.fs_write(fd, vim.fn.json_encode(data))

--- a/lua/lsp-toggle/toggle.lua
+++ b/lua/lsp-toggle/toggle.lua
@@ -6,8 +6,6 @@ local utils = require('lsp-toggle.utils')
 local M = {}
 
 function M.handle_toggle()
-	local opts = require('lsp-toggle.config').options
-
 	local cursor_pos = vim.api.nvim_win_get_cursor(0)
 	local cursor_line = cursor_pos[1]
 	local line_text = vim.api.nvim_buf_get_lines(0, cursor_line - 1, cursor_line, false)[1]
@@ -22,8 +20,12 @@ function M.handle_toggle()
 	end
 
 	window.print_display(utils.clients)
-	if opts.cache then
-		file.save(utils.clients)
+	if not require('lsp-toggle.config').options.cache then
+		return
+	end
+
+	if not file.save(utils.clients) then
+		vim.notify('[FILE] Failed to save cache!', vim.log.levels.WARN)
 	end
 end
 

--- a/lua/lsp-toggle/utils.lua
+++ b/lua/lsp-toggle/utils.lua
@@ -10,14 +10,11 @@ function M.load_all_clients()
 	local excluded = require('lsp-toggle.config').options.exclude_lsp
 
 	for _, client in ipairs(clients) do
-		if not vim.tbl_contains(excluded, client.name) then
-			M.clients[client.name] = {
+		M.clients[client.name] = vim.list_contains(excluded, client.name) and nil
+			or {
 				enabled = vim.lsp.is_enabled(client.name),
 				server_name = client.name,
 			}
-		else
-			M.clients[client.name] = nil
-		end
 	end
 end
 
@@ -36,20 +33,17 @@ function M.merge_table_pf()
 			client.enabled = false
 		end
 
-		if vim.tbl_contains(excluded, name) then
-			goto continue
-		end
-
-		for fname, fclient in pairs(file_clients) do
-			if fname == name then
-				M.clients[fname] = fclient
-				added = true
+		if not vim.tbl_contains(excluded, name) then
+			for fname, fclient in pairs(file_clients) do
+				if fname == name then
+					M.clients[fname] = fclient
+					added = true
+				end
+			end
+			if not added then
+				M.clients[name] = client
 			end
 		end
-		if not added then
-			M.clients[name] = client
-		end
-		::continue::
 	end
 end
 


### PR DESCRIPTION
## Changes

- `fileutils.set_file_path()` always receives an argument (it's never been used optionally)
- `fileutils.save()` returns a boolean instead of `true|nil`
- Added a warning if `fileutils.save()` returns `false`
- `return nil` --> `return`. The former is redundant
- Got rid of `goto continue` in for loops. From experience it's problematic.
- Simplified `utils` statements