### PR TITLE
fix(window): improved file structure

### DIFF
--- a/lua/lsp-toggle/window.lua
+++ b/lua/lsp-toggle/window.lua
@@ -19,9 +19,9 @@ function M.print_display(clients)
 
 	local safe_fn = vim.schedule_wrap(function()
 		vim.api.nvim_buf_set_lines(M.window_buf, 0, -1, false, M.out_buf_table)
-		vim.api.nvim_set_option_value('modifiable', false, { buf = M.window_buf })
+		vim.bo[M.window_buf].modifiable = false
 	end)
-	vim.api.nvim_set_option_value('modifiable', true, { buf = M.window_buf })
+	vim.bo[M.window_buf].modifiable = true
 	safe_fn()
 end
 

--- a/lua/lsp-toggle/window.lua
+++ b/lua/lsp-toggle/window.lua
@@ -1,11 +1,15 @@
 local utils = require('lsp-toggle.utils')
 
 local M = {}
+
+---@type string[]
 M.out_buf_table = {}
 
 ---@param clients table<string, { enabled: boolean, server_name: string }>
 function M.print_display(clients)
 	M.out_buf_table = {}
+
+	-- NOTE: Using `#clients` is not reliable because `clients` is not list-like
 	for _, tb_server in pairs(clients) do
 		table.insert(
 			M.out_buf_table,
@@ -28,16 +32,14 @@ function M.open_window()
 		return
 	end
 
-	local opts = require('lsp-toggle.config').options
-
 	utils.merge_table_pf()
-
 	local dynamic_height = 0
 	for _, _ in pairs(utils.clients) do
-		dynamic_height = dynamic_height + 1
+		dynamic_height = dynamic_height + 1 ---@type integer
 	end
 
-	if dynamic_height <= 0 or dynamic_height >= opts.max_height then
+	local opts = require('lsp-toggle.config').options
+	if dynamic_height < 1 or dynamic_height > opts.max_height then
 		dynamic_height = 1
 	end
 


### PR DESCRIPTION
## Changes

- Added annotations/comments for more clarity
- For readability use `not_zero < 1` instead of `not_zero <= 0`
- Replaced `vim.api.nvim_set_option_value()` with `vim.bo[bufnr]` (simpler, less prone to deprecations, and easier to write)